### PR TITLE
Bump `@actions/checkout` and `peter-evans/create-pull-request` versions

### DIFF
--- a/.github/workflows/process-form-submission.yml
+++ b/.github/workflows/process-form-submission.yml
@@ -12,16 +12,17 @@ jobs:
     name: Process Form
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Add new file to workspace
-        run: "jq '.client_payload.form' $GITHUB_EVENT_PATH > _data/submissions/$SUBMISSION_REF.json"
+        run: "jq '.client_payload.form' $GITHUB_EVENT_PATH > _data/$REPOSITORY/submissions/$SUBMISSION_REF.json"
         env:
           SUBMISSION_REF: ${{ github.event.client_payload.form.submission_ref }}
+          REPOSITORY: ${{ github.event.client_payload.form.repository }}
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           commit-message: Add form submission
           committer: GitHub <noreply@github.com>
@@ -37,11 +38,11 @@ jobs:
             - form_name: ${{ github.event.client_payload.form.form_name }}
             - form_version: ${{ github.event.client_payload.form.form_version }}
             - submission_ref: ${{ github.event.client_payload.form.submission_ref }}
-            - submission_date: ${{ github.event.client_payload.form.submission_date}}
+            - submission_date: ${{ github.event.client_payload.form.submission_date }}
 
             View the submitted JSON in the "Files changed" tab above.
 
-            Merge this PR to add the submission to `_data/submissions`.
+            Merge this PR to add the submission to `_data/${{ github.event.client_payload.form.repository }}/submissions`.
           labels: |
             form submission
             automated pr


### PR DESCRIPTION
While investigating the list submission found in similar WAI resources, found that the following GitHub Actions need to be updated before upcoming deprecations also cause additional issues:

* Bump `actions/checkout@v2` -> `actions/checkout@v3`
* Bump `peter-evans/create-pull-request@v3` -> `peter-evans/create-pull-request@v4`

Additionally, the file path to the submission folder seems to have been outdated so I've done my best to align with how it's handled in similar WAI resources based on the file structure.