### PR TITLE
Update ad56ac50-9a6f-11ee-89bd-6f506cafee02.json

### DIFF
--- a/_data/wai-evaluation-tools-list/submissions/ad56ac50-9a6f-11ee-89bd-6f506cafee02.json
+++ b/_data/wai-evaluation-tools-list/submissions/ad56ac50-9a6f-11ee-89bd-6f506cafee02.json
@@ -1,5 +1,5 @@
 {
-  "a11yloc": "https://monsido.com/accessibility-statement",
+  "a11yloc": "",
   "actrules": "",
   "assists": [
     "Generating reports of evaluation results",


### PR DESCRIPTION
Deleted a11yloc because it is not a specific accessibility statement for the tool. Change accepted by vendor.