### PR TITLE
Add nofollow, noopener, noreferrer to external links

### DIFF
--- a/_includes/wai-evaluation-tools-list/liquid/tool.liquid
+++ b/_includes/wai-evaluation-tools-list/liquid/tool.liquid
@@ -5,7 +5,7 @@
 
 {% assign toolsDataSorted = toolsData | sort_natural: include.sort_key %}
 {% for tool in toolsDataSorted %}
-{% capture tool_title %}<a href="{{ tool.website }}" target="_blank"><h3>{{ tool.title }}</h3>
+{% capture tool_title %}<a href="{{ tool.website }}" target="_blank" rel="nofollow noopener noreferrer"><h3>{{ tool.title }}</h3>
 {% include_cached icon.html name="external-link" aria-label="Open tool in new window" %}</a> 
 <div class="subheader">
 <p class="leftColHeader">by {{ tool.provider }}</p>
@@ -133,7 +133,7 @@ Show more features
 </div>
 {% if tool.a11yloc != "" %}
 <div class="colRow">
-	<img src="{{ "/content-images/wai-evaluation-tools-list/accessibilitystatement.png" | relative_url }}" alt="Accessibility statement" /><p><a href="{{tool.a11yloc}}" target="_blank">Accessibility statement</a> available</p>
+	<img src="{{ "/content-images/wai-evaluation-tools-list/accessibilitystatement.png" | relative_url }}" alt="Accessibility statement" /><p><a href="{{tool.a11yloc}}" target="_blank" rel="nofollow noopener noreferrer">Accessibility statement</a> available</p>
 </div>
 {% endif %}
 {% if tool.actrules != "" and tool.actrules != "https://www.w3.org/WAI/standards-guidelines/act/implementations/"%}


### PR DESCRIPTION
Resolves https://github.com/w3c/wai-evaluation-tools-list/issues/259

- Add "nofollow" to external links (tool link + accessibility statement link)
- Add "noopener" & "noreferrer" for [security reasons](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#security_and_privacy), since `target="_blank"` is used. In newer browser versions, the protection is implicit; it is added here as a best practice, to protect users of older browser versions.