### PR TITLE
Update 7b824100-90bc-11ef-9a48-2bea246cb06f.json

### DIFF
--- a/_data/wai-evaluation-tools-list/submissions/7b824100-90bc-11ef-9a48-2bea246cb06f.json
+++ b/_data/wai-evaluation-tools-list/submissions/7b824100-90bc-11ef-9a48-2bea246cb06f.json
@@ -24,7 +24,8 @@
   "form_name": "submission",
   "form_version": "1",
   "guideline": [
-    "WCAG 2.1"
+    "WCAG 2.1",
+    "WCAG 2.0"
   ],
   "language": [
     "en"


### PR DESCRIPTION
Add WCAG 2.0 to wick-a11y tool. 
Vendor requests that PR434 be withdrawn and that the current data published from PR339 be maintained in list, only adding WCAG 2.0.