### PR TITLE
Display tool and provider names in form submission PRs for easier management

### DIFF
--- a/.github/workflows/process-form-submission.yml
+++ b/.github/workflows/process-form-submission.yml
@@ -31,7 +31,7 @@ jobs:
           branch: form-submission/${{ github.event.client_payload.form.submission_ref }}
           branch-suffix: random # handle concurrent submissions of same form id
           delete-branch: true
-          title: "New form submission – ${{ github.event.client_payload.form.title }} ${{ github.event.client_payload.form.provider }}"
+          title: "New form submission: ${{ github.event.client_payload.form.title }} – ${{ github.event.client_payload.form.provider }}"
           body: |
             New form submission:
             - Tool name: ${{ github.event.client_payload.form.title }}

--- a/.github/workflows/process-form-submission.yml
+++ b/.github/workflows/process-form-submission.yml
@@ -31,12 +31,11 @@ jobs:
           branch: form-submission/${{ github.event.client_payload.form.submission_ref }}
           branch-suffix: random # handle concurrent submissions of same form id
           delete-branch: true
-          title: "New form submission '${{ github.event.client_payload.form.form_name }}' - ${{ github.event.client_payload.form.submission_ref }}"
+          title: "New form submission – ${{ github.event.client_payload.form.title }} ${{ github.event.client_payload.form.provider }}"
           body: |
             New form submission:
-
-            - form_name: ${{ github.event.client_payload.form.form_name }}
-            - form_version: ${{ github.event.client_payload.form.form_version }}
+            - Tool name: ${{ github.event.client_payload.form.title }}
+            - Vendor / organization: ${{ github.event.client_payload.form.provider }}
             - submission_ref: ${{ github.event.client_payload.form.submission_ref }}
             - submission_date: ${{ github.event.client_payload.form.submission_date }}
 


### PR DESCRIPTION
This PR displays the tool and vendor names in the PR titles, instead of `form_name` (always "submission") and UUID.

This PR also adds this information to the PR description, in replacement of `form_name` (always "submission") and `form_version` (always "1").

PR title would be:

```
New form submission: ACME Tool – ACME Inc.
```

Instead of:

```
New form submission 'submission' - 31e59c21-3354-47e2-b978-d89c4f6777e6
```

