### PR TITLE
Remove outdated code triggering an error

### DIFF
--- a/_includes/wai-evaluation-tools-list/js/submission.js
+++ b/_includes/wai-evaluation-tools-list/js/submission.js
@@ -1,8 +1,6 @@
 const submitForm = document.querySelector('form[name="submission"]');
 
 if (submitForm) {
-
-    document.getElementById('update').valueAsDate = new Date();
     
     _addLine();
 


### PR DESCRIPTION
The "date of most recent update" field (ID: update) was removed by 2d175b6bff404aabb52bfc6565fbb325d90c16fd.

Resolves https://github.com/w3c/wai-evaluation-tools-list/issues/383.