### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/process-form-submission.yml
+++ b/.github/workflows/process-form-submission.yml
@@ -11,9 +11,12 @@ jobs:
   process-submission:
     name: Process Form
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
       - name: Add new file to workspace
         run: "jq '.client_payload.form' $GITHUB_EVENT_PATH > _data/$REPOSITORY/submissions/$SUBMISSION_REF.json"
         env:
@@ -21,7 +24,7 @@ jobs:
           REPOSITORY: ${{ github.event.client_payload.form.repository }}
       - name: Create the pull request
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
         with:
           commit-message: Add form submission
           committer: GitHub <noreply@github.com>


### PR DESCRIPTION
This PR:
- pins actions to a full-length commit SHA, following GitHub's recommendations
- bumps `checkout` from v6 to v7.0.1
- sets more specific permissions

Successful consecutive submission: https://github.com/w3c/wai-evaluation-tools-list/pull/1241